### PR TITLE
Added Group Descriptions to Exporters and updated Privacy Policy guide to drop use of deprecated classes

### DIFF
--- a/includes/Privacy/Privacy.php
+++ b/includes/Privacy/Privacy.php
@@ -121,10 +121,11 @@ class Privacy {
 
         if ( $subscriber ) {
             $data_to_export[] = [
-                'group_id'      => 'wemail_subscriber',
-                'group_label'   => __( 'weMail Subscriber Data', 'wemail' ),
-                'item_id'       => 'wemail-subscriber',
-                'data'          => $this->get_subscriber_data( $subscriber ),
+                'group_id'          => 'wemail_subscriber',
+                'group_label'       => __( 'weMail Subscriber Data', 'wemail' ),
+                'group_description' => __( 'The weMail subscriber data.', 'wemail' ),
+                'item_id'           => 'wemail-subscriber',
+                'data'              => $this->get_subscriber_data( $subscriber ),
             ];
         }
 

--- a/includes/Privacy/privacy-policy-content.php
+++ b/includes/Privacy/privacy-policy-content.php
@@ -1,5 +1,5 @@
-<div contenteditable="false">
-    <p class="wp-policy-help">
+<div class="wp-suggested-text">
+    <p class="privacy-policy-tutorial">
         <?php _e( 'weMail Privacy Policy', 'wemail' ); ?>
     </p>
 </div>


### PR DESCRIPTION
Adds support for group_description for privacy exporters which was added in WP5.3 through [WPCoreChangeset#45825](https://core.trac.wordpress.org/changeset/45825) and [WPCoreTracTicket#45491](https://core.trac.wordpress.org/ticket/45491)

Update Suggested Privacy Policy text to utilize privacy-policy-tutorial css class instead of wp-policy-help as it was deprecated. Also wrap the contents in the wp-suggested-text div to style the section to match WordPress. This follows from [WPCoreTrac#49282](https://core.trac.wordpress.org/ticket/49282) and although back-compat is being introduced in WP5.4 as of [WPChangeset#47112](https://core.trac.wordpress.org/changeset/47112) this change will better support users of WP5.1-5.4

This also removes the wrapping <div contenteditable="false"> as it's now unnecessary. As long as the content uses the proper privacy-policy-tutorial class then the WP Privacy Policy Guide section copy action will avoid copying that content. The contenteditable divs were there originally when the contents was fully copied due to not using the appropriate class, and when originally the entire guide would be dumped into the WYSIWYG editor with wp-policy-help sections being highlighted.